### PR TITLE
Added nand configs + cleanup

### DIFF
--- a/XNAND.c
+++ b/XNAND.c
@@ -1,6 +1,4 @@
 #include "XNAND.h"
-#include "XSPI.h"
-#include <stdio.h>
 
 void XNAND_ClearStatus() {
   uint8_t tmp[4];

--- a/XNAND.h
+++ b/XNAND.h
@@ -1,7 +1,9 @@
 #ifndef _XNAND_H_
 #define _XNAND_H_
 
+#include <stdio.h>
 #include <inttypes.h>
+#include "XSPI.h"
 
 void XNAND_ClearStatus(void);
 uint16_t XNAND_GetStatus(void);

--- a/XSPI.c
+++ b/XSPI.c
@@ -34,7 +34,7 @@ void XSPI_Shutdown(void) {
   PINLOW(XX);
   PINLOW(EJ);
 
-  gpioDelay(50000);
+  handshakeDelay();
 
   PINHIGH(EJ);
 }
@@ -42,17 +42,17 @@ void XSPI_Shutdown(void) {
 void XSPI_EnterFlashmode(void) {
   PINLOW(XX);
 
-  gpioDelay(50000);
+  handshakeDelay();
 
   PINLOW(SS);
   PINLOW(EJ);
 
-  gpioDelay(50000);
+  handshakeDelay();
 
   PINHIGH(XX);
   PINHIGH(EJ);
 
-  gpioDelay(50000);
+  handshakeDelay();
 
   PINLOW(SS);
   IN_FLASHMODE = 1;
@@ -63,7 +63,7 @@ void XSPI_LeaveFlashmode(uint8_t force) {
     PINHIGH(SS);
     PINLOW(EJ);
 
-    gpioDelay(50000);
+    handshakeDelay();
 
     PINLOW(XX);
     PINHIGH(EJ);
@@ -74,7 +74,6 @@ void XSPI_LeaveFlashmode(uint8_t force) {
 
 void XSPI_Read(uint8_t reg, uint8_t *buf) {
   PINLOW(SS);
-  gpioDelay(2);
 
   XSPI_PutByte((reg << 2) | 1);
   XSPI_PutByte(0xFF);
@@ -90,7 +89,6 @@ uint16_t XSPI_ReadWord(uint8_t reg) {
   uint16_t res;
 
   PINLOW(SS);
-  gpioDelay(2);
 
   XSPI_PutByte((reg << 2) | 1);
   XSPI_PutByte(0xFF);
@@ -107,7 +105,6 @@ uint8_t XSPI_ReadByte(uint8_t reg) {
   uint8_t res;
 
   PINLOW(SS);
-  gpioDelay(2);
 
   XSPI_PutByte((reg << 2) | 1);
   XSPI_PutByte(0xFF);
@@ -121,7 +118,6 @@ uint8_t XSPI_ReadByte(uint8_t reg) {
 
 void XSPI_Write(uint8_t reg, uint8_t *buf) {
   PINLOW(SS);
-  gpioDelay(2);
 
   XSPI_PutByte((reg << 2) | 2);
   XSPI_PutByte(*buf++);

--- a/XSPI.h
+++ b/XSPI.h
@@ -20,11 +20,10 @@ gpioSetMode(PIN, PI_INPUT)
 
 #define PINHIGH(PIN) gpioWrite(PIN, 1)
 #define PINLOW(PIN) gpioWrite(PIN, 0)
-
 #define PINGET(PIN) gpioRead(PIN)
 
 #define _delay_ms(MS) delay(MS)
-
+#define handshakeDelay() gpioDelay(50000)
 void XSPI_Init(void);
 
 void XSPI_Powerup(void);

--- a/main.c
+++ b/main.c
@@ -8,6 +8,11 @@
 uint8_t FlashConfig1[4];
 uint8_t FlashConfig2[4];
 
+uint32_t blockSize;
+uint32_t blockCount;
+uint32_t pageSize;
+uint32_t pageCount;
+
 void cleanup(void) {
   printf("Leaving flashmode!\n");
   XSPI_LeaveFlashmode(0);
@@ -16,31 +21,34 @@ void cleanup(void) {
 void read_nand(uint32_t start, uint32_t blocks, uint8_t *buffer) {
   printf("Reading flash blocks 0x%04x-0x%04x...\n", start, blocks);
   uint32_t wordsLeft = 0;
-  uint32_t nextPage = start << 5;
+  uint32_t nextPage = start;
 
-  uint32_t len = blocks * (0x4200 / 4); // block size + spares
+  // Len is total number of 32 bit words (4 bytes) we need to get
+  uint32_t len = blocks * (blockSize / 4); // block size + spares
   while (len) {
     uint8_t readNow;
 
-    if ((nextPage >> 5) % 4 == 0) {
-      printf("0x%x\r", nextPage >> 5);
-    }
+    printf("Block: 0x%04x\r", nextPage / pageCount);
 
     if (!wordsLeft) {
+      //Set Read Page
       XNAND_StartRead(nextPage);
       nextPage++;
-      wordsLeft = 0x84;
+      wordsLeft = pageSize / 4;
     }
 
+    //How many words we are about to read
     readNow = (len < wordsLeft) ? len : wordsLeft;
+    //Read Page to Buffer
     XNAND_ReadFillBuffer(buffer, readNow);
 
+    //Iterate
     buffer += (readNow * 4);
     wordsLeft -= readNow;
     len -= readNow;
   }
 
-  printf("\nRead 0x%04x/%04x blocks\n", nextPage >> 5, blocks);
+  printf("\nRead 0x%04x/0x%04x blocks\n", nextPage / pageCount, blocks);
 }
 
 void nand_to_file(char *outputFilename) {
@@ -54,15 +62,73 @@ void nand_to_file(char *outputFilename) {
   }
 
   uint32_t start = 0x00;
-  uint32_t blocks = 0x400;
-  uint32_t buff_size = sizeof(uint8_t) * blocks * 0x4200;
+  // Calculate how big our buffer is in bytes.
+  uint32_t buff_size = sizeof(uint8_t) * blockCount * blockSize;
   uint8_t *buff = (uint8_t *)malloc(buff_size);
-  read_nand(start, blocks, buff);
 
+  // Read nand into buffer
+  read_nand(start, blockCount, buff);
+
+  // Write buffer to file
   fwrite(buff, buff_size, 1, ofp);
-  fclose(ofp);
 
+  // Cleanup
+  fclose(ofp);
   free(buff);
+}
+
+// Set nand block information based on the nand config identifier
+// https://github.com/Free60Project/wiki/blob/master/NAND.md
+void set_config(uint32_t config) {
+  //Large Block: 256MB NAND
+  if(0x008A3020 == config) {
+    blockSize = 0x21000 ;
+    //After block 1000 is used as Memory Unit
+    //blockCount = 0x800;
+    blockCount = 0x200;
+    pageSize = 0x210;
+    pageCount = 0x100;
+    //64MB Total size / 65MB With Spares (OS)
+    //256MB Total size / 264MB With Spares (OS+MU)
+    return;
+  }
+
+  //Large Block: 256/512MB NAND
+  if(0x00aa3020 == config) {
+    blockSize = 0x21000 ;
+    //After block 0x200 (64M) is used as Memory Unit
+    //Actual total blocks is 0x1000
+    blockCount = 0x200;
+    blockCount = 0x200;//short test
+    pageSize = 0x210;
+    pageCount = 0x100;
+    //64MB Total size / 65MB With Spares (OS)
+    //512MB Total size / 528MB With Spares (OS+MU)
+    return;
+  }
+
+  // Small Block: 16MB NAND
+  if(0x00aaaaaa == config) {//TODO: Need Config ID
+    blockSize = 0x4200;
+    blockCount = 0x400;
+    pageSize = 0x210;
+    pageCount = 0x20;
+    //16MB Total size / 16.5MB With Spares
+    return;
+  }
+
+  // Small Block: 64MB NAND
+  if(0x00aaaabb == config) {//TODO: Need Config ID
+    blockSize = 0x4200;
+    blockCount = 0x1000;
+    pageSize = 0x210;
+    pageCount = 0x20;
+    //64MB Total size / 65MB With Spares
+    return;
+  }
+
+  printf("No idea what chip this is.\n");
+  exit(-1);
 }
 
 int main(void) {
@@ -91,9 +157,10 @@ int main(void) {
     exit(1);
   }
 
+  set_config(flash_config2);
+
   nand_to_file("nand1.bin");
   nand_to_file("nand2.bin");
-  nand_to_file("nand3.bin");
 
   exit(0);
 }


### PR DESCRIPTION
Added config detection for different nand configs.
  Note: We still need more of the config numbers populated.
Did some general cleanup.
Did a bunch of commenting and removed some magic numbers.

I have done multiple 64mb NAND dumps that all match.
They currently take ~30mins to dump a single attempt.
Next step is trying to make things faster.